### PR TITLE
Fix to use stderr and exit status 1 when error occurs

### DIFF
--- a/bin/gls.rs
+++ b/bin/gls.rs
@@ -1,4 +1,5 @@
 extern crate g_rs_commands;
+use std::process;
 use g_rs_commands::ls;
 use g_rs_commands::parser::commands::Commands;
 use g_rs_commands::parser::command_line::CommandLine;
@@ -7,6 +8,9 @@ fn main () {
   let ls_commands = ls::ls_commands::LsCommands::new(CommandLine::new());
   match ls_commands.run() {
     Ok(_) => {},
-    Err(e) => println!("{}", e),
+    Err(e) => {
+        eprintln!("{}", e);
+        process::exit(1);
+    },
   }
 }

--- a/bin/grm.rs
+++ b/bin/grm.rs
@@ -1,4 +1,5 @@
 extern crate g_rs_commands;
+use std::process;
 use g_rs_commands::rm::rm_commands;
 use g_rs_commands::parser::command_line::CommandLine;
 use g_rs_commands::parser::commands::Commands;
@@ -7,6 +8,9 @@ fn main() {
   let rm_commands = rm_commands::RmCommands::new(CommandLine::new());
   match rm_commands.run() {
     Ok(_) => {},
-    Err(e) => println!("{}", e),
+    Err(e) => {
+        eprintln!("{}", e);
+        process::exit(1);
+    },
   }
 }


### PR DESCRIPTION
Thanks for a great product!

- Current implementation uses stdout to put error log. Fix this to use stderr instead.
- Exit status is always 0 even when handling errors. Fixed to use exit status 1 in a customary way.